### PR TITLE
Fix ownership of exhibitor jar to node[:exhibitor][:user] when using …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.4.1
+* Fix ownership of downloaded Exhibitor jar
+
 ## 0.4.0
 * Just run `install` instead of `default` recipe (contributed by
   @DorianZaccaria)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Simple Finance Technology Corp.'
 maintainer_email 'ops@simple.com'
 license          'Apache v2.0'
 description      'Installs Netflix Exhibitor'
-version          '0.4.0'
+version          '0.4.1'
 
 depends          'build-essential'
 depends          'java'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,7 +43,7 @@ node.override[:exhibitor][:jar_dest] = ::File.join(node[:exhibitor][:install_dir
 
 if node[:exhibitor][:install_method] == 'download'
   remote_file node[:exhibitor][:jar_dest] do
-    owner 'root'
+    owner node[:exhibitor][:user]
     mode 00600
     source node[:exhibitor][:mirror]
     checksum node[:exhibitor][:checksum]
@@ -84,7 +84,6 @@ end
 template ::File.join(node[:exhibitor][:install_dir], 'log4j.properties') do
   source 'log4j.properties.erb'
   owner node[:exhibitor][:user]
-  group 'root'
   mode 00600
   variables(loglevel: node[:exhibitor][:loglevel])
 end


### PR DESCRIPTION
…download provisioning method