### PR TITLE
enabling service start on variable

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,8 @@ class Chef::Resource
   include Exhibitor::Util
 end
 
-package 'patch' do
+package_name = node[:exhibitor][:patch_package] || 'patch'
+package package_name do
   action :nothing
 end.run_action(:install)
 

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -29,5 +29,7 @@ runit_service 'exhibitor' do
     log4j: ::File.join(node[:exhibitor][:install_dir], 'log4j.properties'),
     cli: format_cli_options(node[:exhibitor][:cli])
   })
-  action [:enable, :start]
+  actions = [:enable]
+  actions << :start if not node[:exhibitor][:no_start]
+  action actions
 end


### PR DESCRIPTION
Some might want to have the service added but not started.
If so, i suggest passing the attribute `:no_start`, like this:
````ruby
  attribute :exhibitor, { no_start: true }
````
The service will be enabled but not started.
This does not change default behavior, which keeps on starting the service.
What do you think ?