### PR TITLE
explicitly calls 'sh /usr/local/bin/gradle' for more systems compatibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,8 @@ default['exhibitor']['transaction_dir'] = '/tmp/zookeeper'
 default['exhibitor']['log_index_dir']   = '/tmp/zookeeper_log_indexes'
 default['exhibitor']['log_to_syslog']   = '1'
 
+default['exhibitor']['gradle_build_cmd'] = 'gradle shadowJar'
+
 default['exhibitor']['patch_package'] = 'patch'
 
 # Command line arguments

--- a/recipes/_exhibitor_build.rb
+++ b/recipes/_exhibitor_build.rb
@@ -37,7 +37,7 @@ if should_install_exhibitor?(node['exhibitor']['jar_dest'])
   execute 'build exhibitor' do
     user 'root'
     cwd build_path
-    command 'gradle shadowJar'
+    command node['exhibitor']['gradle_build_cmd']
   end
 
   gradle_artifact = ::File.join(build_path,


### PR DESCRIPTION
regarding https://github.com/SimpleFinance/chef-exhibitor/issues/31

takes care of not needing to modify $PATH on systems without /usr/local/bin defined, and hardened bash permission